### PR TITLE
feat(analysis stream): Add cancelable analysis with UI state lockout during processing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -165,6 +165,7 @@ def analyze_stream():
     def gen():
         for f in extracted_frames:
             res = analyze_image(f, context)
+            analysis_results[f] = res
             yield f"data: {f} → {res}\n\n"
         yield "data: Analysis complete\n\n"
     return Response(stream_with_context(gen()),

--- a/src/app.py
+++ b/src/app.py
@@ -159,6 +159,17 @@ def analyze():
     flash('Analysis complete')
     return redirect(url_for('results'))
 
+@app.route('/analyze_stream')
+def analyze_stream():
+    context = request.args.get('context')
+    def gen():
+        for f in extracted_frames:
+            res = analyze_image(f, context)
+            yield f"data: {f} → {res}\n\n"
+        yield "data: Analysis complete\n\n"
+    return Response(stream_with_context(gen()),
+                    mimetype='text/event-stream')
+
 @app.route('/results')
 def results():
     """Route: Render analysis results in the results view."""

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -266,6 +266,7 @@ document.addEventListener('DOMContentLoaded', () => {
           setPageDisabled(false);
           analyzeBtn.textContent  = 'Run Analysis';
           analyzing               = false;
+          window.location.href    = '/results';
         }
       };
 

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -9,11 +9,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const statusText     = document.getElementById('upload-status');
   const extractBtn     = document.getElementById('extract-btn');
   const analyzeBtn     = document.getElementById('analyze-btn');
+  const preRemoveBtn = document.getElementById('pre-remove-btn');
   const viewLinks      = Array.from(document.querySelectorAll('a'));
 
   // Enable or disable page controls during upload/extraction
   function setPageDisabled(disabled) {
-    [fileInput, extractBtn, analyzeBtn].forEach(el => el && (el.disabled = disabled));
+    [fileInput, extractBtn, analyzeBtn, preRemoveBtn].forEach(el => el && (el.disabled = disabled));
     viewLinks.forEach(a => a.style.pointerEvents = disabled ? 'none' : '');
   }
 

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -9,12 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const statusText     = document.getElementById('upload-status');
   const extractBtn     = document.getElementById('extract-btn');
   const analyzeBtn     = document.getElementById('analyze-btn');
-  const cancelAnalysis = document.getElementById('cancel-analysis');
   const viewLinks      = Array.from(document.querySelectorAll('a'));
 
   // Enable or disable page controls during upload/extraction
   function setPageDisabled(disabled) {
-    [fileInput, extractBtn, analyzeBtn, cancelAnalysis].forEach(el => el && (el.disabled = disabled));
+    [fileInput, extractBtn, analyzeBtn].forEach(el => el && (el.disabled = disabled));
     viewLinks.forEach(a => a.style.pointerEvents = disabled ? 'none' : '');
   }
 
@@ -229,10 +228,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // --- Analysis Section (SSE) ---
-  const analysisProg = document.getElementById('analysis-progress');
-  let analyzing     = false;
+  const analysisProg  = document.getElementById('analysis-progress');
+  let analyzing       = false;
 
-  if (analyzeBtn && cancelAnalysis && analysisProg) {
+  if (analyzeBtn && analysisProg) {
     analyzeBtn.addEventListener('click', (e) => {
       e.preventDefault();
 
@@ -241,9 +240,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (window._analysisSource) window._analysisSource.close();
         fetch('/analyze/abort', { method: 'POST' });
         setPageDisabled(false);
-        analyzeBtn.textContent      = 'Run Analysis';
-        cancelAnalysis.style.display = 'none';
-        analyzing                   = false;
+        analyzeBtn.textContent  = 'Run Analysis';
+        analyzing               = false;
         return;
       }
 
@@ -252,10 +250,9 @@ document.addEventListener('DOMContentLoaded', () => {
       analysisProg.textContent = '';
 
       setPageDisabled(true);
-      analyzeBtn.disabled          = false; // so user can click “Stop”
-      analyzeBtn.textContent       = 'Stop Analysis';
-      cancelAnalysis.style.display = 'inline-block';
-      analyzing                     = true;
+      analyzeBtn.disabled     = false;
+      analyzeBtn.textContent  = 'Stop Analysis';
+      analyzing               = true;
 
       if (window._analysisSource) window._analysisSource.close();
       const src = new EventSource(`/analyze_stream?context=${encodeURIComponent(context)}`);
@@ -266,9 +263,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (evt.data.startsWith("Analysis complete")) {
           window._analysisSource.close();
           setPageDisabled(false);
-          analyzeBtn.textContent       = 'Run Analysis';
-          cancelAnalysis.style.display = 'none';
-          analyzing                    = false;
+          analyzeBtn.textContent  = 'Run Analysis';
+          analyzing               = false;
         }
       };
 
@@ -277,24 +273,14 @@ document.addEventListener('DOMContentLoaded', () => {
         analysisProg.textContent += "Error in analysis stream\n";
         window._analysisSource.close();
         setPageDisabled(false);
-        analyzeBtn.textContent       = 'Run Analysis';
-        cancelAnalysis.style.display = 'none';
-        analyzing                    = false;
+        analyzeBtn.textContent  = 'Run Analysis';
+        analyzing               = false;
       };
-    });
-
-    cancelAnalysis.addEventListener('click', () => {
-      // identical cancel logic
-      if (window._analysisSource) window._analysisSource.close();
-      fetch('/extract/abort', { method: 'POST' });
-      setPageDisabled(false);
-      analyzeBtn.textContent      = 'Run Analysis';
-      cancelAnalysis.style.display = 'none';
-      analyzing                   = false;
     });
   } else {
     console.warn('Analysis elements not found in DOM');
   }
+
 
   // --- Frame Removal Section ---
   const removeFramesBtn = document.getElementById('remove-frames-btn');

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -48,17 +48,21 @@
   </section>
 
   <!-- Analysis Context & Submission Form -->
-  <form action="{{ url_for('analyze') }}" method="post">
+  <form id="analysis-form" action="{{ url_for('analyze') }}" method="post">
     <label for="context">Context:</label>
-    <!-- Input for user to specify analysis context -->
-    <input type="text"
-           id="context"
-           name="context"
-           size="80"
-           value="Site type: open pit; Mineral: Gold; tropical climate, rainfall patterns…">
-    <button type="submit">Run Analysis</button>
+    <input
+      type="text"
+      id="context"
+      name="context"
+      size="80"
+      value="Site type: open pit; Mineral: Gold; tropical climate, rainfall patterns…"
+    >
+    <button type="button" id="analyze-btn">Run Analysis</button>
+    <button type="button" id="cancel-analysis" style="display:none">Stop Analysis</button>
   </form>
 
+  <!-- Analysis progress -->
+  <pre id="analysis-progress" style="background:#eef; padding:1em; margin-top:1em;"></pre>
   <!-- Navigation links to results and final summary pages -->
   <p><a href="{{ url_for('results') }}">View Frame Results</a></p>
   <p><a href="{{ url_for('final') }}">Show Final Conclusion</a></p>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -58,7 +58,6 @@
       value="Site type: open pit; Mineral: Gold; tropical climate, rainfall patterns…"
     >
     <button type="button" id="analyze-btn">Run Analysis</button>
-    <button type="button" id="cancel-analysis" style="display:none">Stop Analysis</button>
   </form>
 
   <!-- Analysis progress -->


### PR DESCRIPTION
### Description

This pull request introduces a stream-based analysis workflow for the MineWatch AI system. It allows users to receive real-time feedback during frame analysis and provides the ability to cancel the process mid-execution. Additionally, the update enforces interface lockout to prevent conflicting actions during active operations.

---

### Summary of Changes

#### Backend (`app.py`)
- Added a new `GET /analyze_stream` route utilizing Server-Sent Events (SSE).
- Each extracted frame is analyzed in sequence, with results streamed incrementally to the client.
- The response stream concludes with a completion message.
- Results are stored in `analysis_results` for downstream access by the `/results` and `/final` routes.

#### Frontend Template (`index.html`)
- Refactored the analysis form:
  - Replaced form submission with a button event trigger (`type="button"`).
  - Assigned the ID `analyze-btn` to support custom JavaScript interactions.
  - Inserted a `<pre>` block (`id="analysis-progress"`) to display streamed results in real time.

#### Frontend Logic (`main.js`)
- Implemented SSE-based analysis initiation:
  - Connects to `/analyze_stream` using the user-specified context.
  - Streams and appends analysis output to the progress element.
  - Automatically redirects to `/results` upon completion.
- Added cancelation logic:
  - Users can interrupt analysis by clicking the same button, which then aborts the SSE connection.
- UI lockout enhancements:
  - The `setPageDisabled()` function now disables all major action buttons, including `analyze`, `upload`, `extract`, and `remove`.
  - Prevents simultaneous operations that could compromise processing integrity.
